### PR TITLE
Add support for parsing flash and ram sizes

### DIFF
--- a/src/family.rs
+++ b/src/family.rs
@@ -63,10 +63,20 @@ pub struct Mcu {
     pub name: String,
     pub package_name: String,
     pub ref_name: String,
-    #[serde(rename="Flash")]
+    #[serde(rename = "Flash")]
     pub flash_size: String,
-    #[serde(rename="Ram")]
+    #[serde(rename = "Ram")]
     pub ram_size: String,
+}
+
+impl Mcu {
+    pub fn flash_size(&self) -> Option<u32> {
+        self.flash_size.parse().ok()
+    }
+
+    pub fn ram_size(&self) -> Option<u32> {
+        self.ram_size.parse().ok()
+    }
 }
 
 impl Families {

--- a/src/family.rs
+++ b/src/family.rs
@@ -63,6 +63,10 @@ pub struct Mcu {
     pub name: String,
     pub package_name: String,
     pub ref_name: String,
+    #[serde(rename="Flash")]
+    pub flash_size: String,
+    #[serde(rename="Ram")]
+    pub ram_size: String,
 }
 
 impl Families {

--- a/src/main.rs
+++ b/src/main.rs
@@ -244,7 +244,7 @@ fn generate_features(
 
     // Flash sizes
     let mut flash_sizes = mcu_flash_size_map.keys().collect::<Vec<_>>();
-    flash_sizes.sort();
+    flash_sizes.sort_by_key(|s| s.parse::<u32>().unwrap());
     println!("# Features based on Flash size (in kbytes)");
     for size in flash_sizes {
         println!("{} = []", flash_size_to_feature(*size));
@@ -253,7 +253,7 @@ fn generate_features(
 
     // RAM sizes
     let mut ram_sizes = mcu_ram_size_map.keys().collect::<Vec<_>>();
-    ram_sizes.sort();
+    ram_sizes.sort_by_key(|s| s.parse::<u32>().unwrap());
     println!("# Features based on RAM size (in kbytes)");
     for size in ram_sizes {
         println!("{} = []", ram_size_to_feature(*size));

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,6 +37,16 @@ fn eeprom_size_to_feature(size: u32) -> String {
     format!("eeprom-{}", size)
 }
 
+/// Get the Flash size feature for a certain size.
+fn flash_size_to_feature(size: &str) -> String {
+    format!("flash-{}", size)
+}
+
+/// Get the RAM size feature for a certain size.
+fn ram_size_to_feature(size: &str) -> String {
+    format!("ram-{}", size)
+}
+
 fn main() -> Result<(), String> {
     let args = App::new("cube-parse")
         .version(env!("CARGO_PKG_VERSION"))
@@ -87,7 +97,7 @@ fn main() -> Result<(), String> {
     // MCU map
     //
     // This maps a MCU ref name to the corresponding `mcu::Mcu` instance.
-    let mut mcu_map: HashMap<String, mcu::Mcu> = HashMap::new();
+    let mut mcu_map: HashMap<String, (&family::Mcu, mcu::Mcu)> = HashMap::new();
 
     // GPIO map
     //
@@ -105,13 +115,23 @@ fn main() -> Result<(), String> {
     // The keys of this map are EEPROM sizes, the values are Vecs of MCU ref names.
     let mut mcu_eeprom_size_map: HashMap<u32, Vec<String>> = HashMap::new();
 
+    // Flash size map
+    //
+    // The keys of this map are flash sizes, the values are Vecs of MCU ref names.
+    let mut mcu_flash_size_map: HashMap<&str, Vec<String>> = HashMap::new();
+
+    // RAM size map
+    //
+    // The keys of this map are RAM sizes, the values are Vecs of MCU ref names.
+    let mut mcu_ram_size_map: HashMap<&str, Vec<String>> = HashMap::new();
+
     // Iterate through subfamilies, then through MCUs. Fill the maps above with
     // aggregated data.
     for sf in family {
         for mcu in sf {
             // Load MCU data from the XML files
             let mcu_dat = mcu::Mcu::load(&db_dir, &mcu.name)
-                .map_err(|e| format!("Could not load MCU data: {}", e))?;
+                .map_err(|e| format!("Could not load MCU data for mcu {}: {}", &mcu.name, e))?;
 
             // Fill GPIO map
             let gpio_version = mcu_dat.get_ip("GPIO").unwrap().get_version().to_string();
@@ -134,7 +154,19 @@ fn main() -> Result<(), String> {
                     .push(mcu.ref_name.clone());
             }
 
-            mcu_map.insert(mcu.ref_name.clone(), mcu_dat);
+            // Fill flash size map
+            mcu_flash_size_map
+                .entry(&mcu.flash_size)
+                .or_insert(vec![])
+                .push(mcu.ref_name.clone());
+            
+            // Fill RAM size map
+            mcu_ram_size_map
+                .entry(&mcu.ram_size)
+                .or_insert(vec![])
+                .push(mcu.ref_name.clone());
+
+            mcu_map.insert(mcu.ref_name.clone(), (mcu, mcu_dat));
         }
     }
 
@@ -144,6 +176,8 @@ fn main() -> Result<(), String> {
             &mcu_gpio_map,
             &mcu_package_map,
             &mcu_eeprom_size_map,
+            &mcu_flash_size_map,
+            &mcu_ram_size_map,
             &mcu_family,
         )?,
         GenerateTarget::PinMappings => generate_pin_mappings(&mcu_gpio_map, &db_dir)?,
@@ -178,10 +212,12 @@ lazy_static! {
 /// Finally, the MCU features are printed, they act purely as aliases for the
 /// other features.
 fn generate_features(
-    mcu_map: &HashMap<String, mcu::Mcu>,
+    mcu_map: &HashMap<String, (&family::Mcu, mcu::Mcu)>,
     mcu_gpio_map: &HashMap<String, Vec<String>>,
     mcu_package_map: &HashMap<String, String>,
     mcu_eeprom_size_map: &HashMap<u32, Vec<String>>,
+    mcu_flash_size_map: &HashMap<&str, Vec<String>>,
+    mcu_ram_size_map: &HashMap<&str, Vec<String>>,
     mcu_family: &str,
 ) -> Result<(), String> {
     // IO features
@@ -203,6 +239,24 @@ fn generate_features(
     println!("# Features based on EEPROM size (in bytes)");
     for size in eeprom_sizes {
         println!("{} = []", eeprom_size_to_feature(*size));
+    }
+    println!();
+
+    // Flash sizes
+    let mut flash_sizes = mcu_flash_size_map.keys().collect::<Vec<_>>();
+    flash_sizes.sort();
+    println!("# Features based on Flash size (in kbytes)");
+    for size in flash_sizes {
+        println!("{} = []", flash_size_to_feature(*size));
+    }
+    println!();
+
+    // RAM sizes
+    let mut ram_sizes = mcu_ram_size_map.keys().collect::<Vec<_>>();
+    ram_sizes.sort();
+    println!("# Features based on RAM size (in kbytes)");
+    for size in ram_sizes {
+        println!("{} = []", ram_size_to_feature(*size));
     }
     println!();
 
@@ -246,10 +300,16 @@ fn generate_features(
             // GPIO version feature
             dependencies.push(gpio_version_feature.clone());
 
+            let (mcu_info, mcu_dat) = mcu_map.get(mcu).unwrap();
+
             // EEPROM size
-            if let Some(size) = mcu_map.get(mcu).unwrap().get_eeprom_size() {
+            if let Some(size) = mcu_dat.get_eeprom_size() {
                 dependencies.push(eeprom_size_to_feature(size));
             }
+
+            // Flash & RAM size
+            dependencies.push(flash_size_to_feature(&mcu_info.flash_size));
+            dependencies.push(ram_size_to_feature(&mcu_info.ram_size));
 
             mcu_aliases.push(format!(
                 "mcu-{} = [{}]",


### PR DESCRIPTION
This PR should solve part of the problem for stm32-rs/stm32l0xx-hal#170

When generating the MCU features I get the output below for the two MCUs I gave as an example. Which seems to be correct.
```toml
mcu-STM32L051K8Ux = ["stm32l0x1", "ufqfpn32", "io-STM32L051", "eeprom-2048", "flash-64", "ram-8"]
mcu-STM32L071K8Ux = ["stm32l0x1", "ufqfpn32", "io-STM32L071", "eeprom-3072", "flash-64", "ram-20"]
```

About the implementation, I tried to make as little change as possible. I'm not sure the tuple in the hasmap is the cleanest way to do it. A better idea would probably be to merge the two `Mcu` structs. Let me know if you have a better idea for the implementation.

For the flash and ram features it generates the following:
```toml
# Features based on Flash size (in kbytes)
flash-128 = []
flash-16 = []
flash-192 = []
flash-32 = []
flash-64 = []
flash-8 = []

# Features based on RAM size (in kbytes)
ram-2 = []
ram-20 = []
ram-8 = []
```
I think it is quite manageable to handle this manually in the build.rs. But if needed we could generate the if/else wall automatically here too, would that be desired?

I just noticed flash and ram features are sorted alphabetically instead of numerically. I'm going to correct that before you merge this.